### PR TITLE
Adds support for site secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,18 @@
 # Pantheon prototype
 
-[![CircleCI](https://circleci.com/gh/mitlibraries/mitlib-prototype.svg?style=shield)](https://circleci.com/gh/mitlibraries/mitlib-prototype)
+[![CircleCI](https://circleci.com/gh/MITLibraries/mitlib-prototype/tree/master.svg?style=svg)](https://circleci.com/gh/MITLibraries/mitlib-prototype/tree/master)
 [![Dashboard mitlib-prototype](https://img.shields.io/badge/dashboard-mitlib_prototype-yellow.svg)](https://dashboard.pantheon.io/sites/6f00abf5-3d86-46ac-93c6-43eab1f5c8aa#dev/code)
 [![Dev Site mitlib-prototype](https://img.shields.io/badge/site-mitlib_prototype-blue.svg)](http://dev-mitlib-prototype.pantheonsite.io/)
 
 This is a prototype WordPress site.
+
+## Tooling
+
+If you are reading this page on GitHub, you likely need to have the following
+tooling available to you:
+
+* [Composer](https://getcomposer.org/)
+* [Terminus CLI tool](https://pantheon.io/docs/terminus)
+  * [Build Tools plugin](https://github.com/pantheon-systems/terminus-build-tools-plugin)
+  * [Composer plugin](https://github.com/pantheon-systems/terminus-composer-plugin)
+  * [Secrets plugin](https://github.com/pantheon-systems/terminus-secrets-plugin)

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,16 @@
     {
       "type": "vcs",
       "url": "https://github.com/pantheon-systems/wordpress-composer"
+    },
+    {
+      "type": "vcs",
+      "url": "https://github.com/mitlibraries/mitlib-secrets-widget"
     }
   ],
   "require": {
     "php": ">=7.3",
     "composer/installers": "^1.3.0",
+    "mitlibraries/mitlib-secrets-widget": "^0.2.0",
     "pantheon-systems/quicksilver-pushback": "^2",
     "pantheon-systems/wordpress-composer": "*",
     "roots/wp-password-bcrypt": "^1.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aa7120ee8c74ab9ffe901dc50c428f70",
+    "content-hash": "268fdd1295f00b09edb5806fbbab1abe",
     "packages": [
         {
             "name": "composer/installers",
@@ -202,6 +202,37 @@
                 "source": "https://github.com/johnpbloch/wordpress-core-installer/tree/0.1.2"
             },
             "time": "2013-09-09T15:03:37+00:00"
+        },
+        {
+            "name": "mitlibraries/mitlib-secrets-widget",
+            "version": "0.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MITLibraries/mitlib-secrets-widget.git",
+                "reference": "fd4578a8de31b5d802bed24e7d9c9e0980ffe051"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MITLibraries/mitlib-secrets-widget/zipball/fd4578a8de31b5d802bed24e7d9c9e0980ffe051",
+                "reference": "fd4578a8de31b5d802bed24e7d9c9e0980ffe051",
+                "shasum": ""
+            },
+            "type": "wordpress-plugin",
+            "license": [
+                "GPLv2"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Bernhardt",
+                    "email": "mjbernha@mit.edu"
+                }
+            ],
+            "description": "A WordPress plugin that provides an administrative widget to list available secrets",
+            "support": {
+                "source": "https://github.com/MITLibraries/mitlib-secrets-widget/tree/0.2.0",
+                "issues": "https://github.com/MITLibraries/mitlib-secrets-widget/issues"
+            },
+            "time": "2020-03-18T19:07:53+00:00"
         },
         {
             "name": "pantheon-systems/quicksilver-pushback",

--- a/web/wp-config.php
+++ b/web/wp-config.php
@@ -167,6 +167,12 @@ if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ):
 		define( 'DISALLOW_FILE_MODS', true );
 	endif;
 
+	// Load and apply secrets
+	if ( file_exists( $_SERVER['HOME'] . '/files/private/secrets.json' ) ) {
+		$secrets_file = $_SERVER['HOME'] . '/files/private/secrets.json';
+		$secrets = json_decode( file_get_contents( $secrets_file ), 1 );
+	}
+
 endif;
 
 /*


### PR DESCRIPTION
** Why are these changes being introduced:

* Certain site configuration needs to be defined and kept separate from
  source control.

** Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/engx-138

** How does this address that need:

* This adds support for the Terminus Secrets plugin, including:
  * Loading the secrets file (if defined) within wp-config
  * Adding our homegronw secrets widget to the admin dashboard
  * Noting that the secrets plugin is a needed bit of tooling to the
    project readme

** Document any side effects to this change:

* This also fixes the circleCI badge on the readme

#### Developer

- [ ] All new secrets documented in README
- [ ] All new secrets have been added to Pantheon tiers
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Includes new or updated dependencies?

YES
