### PR TITLE
Adds Advanced Custom Fields Pro from private source

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,20 +9,8 @@
       "url": "https://wpackagist.org"
     },
     {
-      "type": "package",
-      "package": {
-        "name": "advanced-custom-fields/advanced-custom-fields-pro",
-        "version": "5.12",
-        "type": "wordpress-plugin",
-        "dist": {
-          "type": "zip",
-          "url": "https://connect.advancedcustomfields.com/index.php?p=pro&a=download"
-        },
-        "require": {
-          "philippbaschke/acf-pro-installer": "^1.0",
-          "composer/installers": "^1.0"
-        }
-      }
+      "type": "composer",
+      "url": "https://pivvenit.github.io/acf-composer-bridge/composer/v3/wordpress-plugin/"
     },
     {
       "type": "vcs",
@@ -43,8 +31,8 @@
   ],
   "require": {
     "php": ">=7.3",
-    "composer/installers": "^1.3.0",
     "advanced-custom-fields/advanced-custom-fields-pro": "^5.12",
+    "composer/installers": "^1.3.0",
     "mitlibraries/mitlib-secrets-widget": "^0.2.0",
     "mjbernha/mitlib-cube": "3.0.0-beta2",
     "mjbernha/mitlib-tesseract": "^2.0.0-beta",
@@ -88,7 +76,8 @@
     "allow-plugins": {
       "composer/installers": true,
       "johnpbloch/wordpress-core-installer": true,
-      "dealerdirect/phpcodesniffer-composer-installer": true
+      "dealerdirect/phpcodesniffer-composer-installer": true,
+      "pivvenit/acf-pro-installer": true
     }
   },
   "extra": {

--- a/composer.json
+++ b/composer.json
@@ -27,12 +27,17 @@
     {
       "type": "vcs",
       "url": "https://github.com/matt-bernhardt/mitlib-cube"
+    },
+    {
+      "type": "vcs",
+      "url": "https://github.com/matt-bernhardt/wp-cfm-acf"
     }
   ],
   "require": {
     "php": ">=7.3",
     "advanced-custom-fields/advanced-custom-fields-pro": "^5.12",
     "composer/installers": "^1.3.0",
+    "level-level/wp-cfm-acf": "0.2.0-beta1",
     "mitlibraries/mitlib-secrets-widget": "^0.2.0",
     "mjbernha/mitlib-cube": "3.0.0-beta2",
     "mjbernha/mitlib-tesseract": "^2.0.0-beta",

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,22 @@
       "url": "https://wpackagist.org"
     },
     {
+      "type": "package",
+      "package": {
+        "name": "advanced-custom-fields/advanced-custom-fields-pro",
+        "version": "5.12",
+        "type": "wordpress-plugin",
+        "dist": {
+          "type": "zip",
+          "url": "https://connect.advancedcustomfields.com/index.php?p=pro&a=download"
+        },
+        "require": {
+          "philippbaschke/acf-pro-installer": "^1.0",
+          "composer/installers": "^1.0"
+        }
+      }
+    },
+    {
       "type": "vcs",
       "url": "https://github.com/pantheon-systems/wordpress-composer"
     },

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
   "require": {
     "php": ">=7.3",
     "composer/installers": "^1.3.0",
+    "advanced-custom-fields/advanced-custom-fields-pro": "^5.12",
     "mitlibraries/mitlib-secrets-widget": "^0.2.0",
     "mjbernha/mitlib-cube": "3.0.0-beta2",
     "mjbernha/mitlib-tesseract": "^2.0.0-beta",

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,10 @@
     },
     {
       "type": "vcs",
+      "url": "https://github.com/mitlibraries/wp-home-page-news"
+    },
+    {
+      "type": "vcs",
       "url": "https://github.com/mitlibraries/wp-pending-posts"
     },
     {
@@ -43,6 +47,7 @@
     "composer/installers": "^1.3.0",
     "level-level/wp-cfm-acf": "0.2.0-beta1",
     "mitlibraries/mitlib-secrets-widget": "^0.2.0",
+    "mitlibraries/wp-home-page-news": "^2.1.0-beta1",
     "mitlibraries/wp-pending-posts": "^1.1.0-beta1",
     "mjbernha/mitlib-cube": "3.0.0-beta2",
     "mjbernha/mitlib-tesseract": "^2.0.0-beta",

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,10 @@
     },
     {
       "type": "vcs",
+      "url": "https://github.com/mitlibraries/wp-pending-posts"
+    },
+    {
+      "type": "vcs",
       "url": "https://github.com/matt-bernhardt/mitlib-tesseract"
     },
     {
@@ -39,6 +43,7 @@
     "composer/installers": "^1.3.0",
     "level-level/wp-cfm-acf": "0.2.0-beta1",
     "mitlibraries/mitlib-secrets-widget": "^0.2.0",
+    "mitlibraries/wp-pending-posts": "^1.1.0-beta1",
     "mjbernha/mitlib-cube": "3.0.0-beta2",
     "mjbernha/mitlib-tesseract": "^2.0.0-beta",
     "pantheon-systems/quicksilver-pushback": "^2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "93eba9f6647b14afce103fbb98432673",
+    "content-hash": "3371d867d896c673a91087d51ba2e6ae",
     "packages": [
         {
             "name": "advanced-custom-fields/advanced-custom-fields-pro",
@@ -244,6 +244,33 @@
                 "source": "https://github.com/johnpbloch/wordpress-core-installer/tree/master"
             },
             "time": "2020-04-16T21:44:57+00:00"
+        },
+        {
+            "name": "level-level/wp-cfm-acf",
+            "version": "0.2.0-beta1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/matt-bernhardt/wp-cfm-acf.git",
+                "reference": "7fa4d9f886353765f8295be674d1ff6a4de642fd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/matt-bernhardt/wp-cfm-acf/zipball/7fa4d9f886353765f8295be674d1ff6a4de642fd",
+                "reference": "7fa4d9f886353765f8295be674d1ff6a4de642fd",
+                "shasum": ""
+            },
+            "type": "wordpress-plugin",
+            "authors": [
+                {
+                    "name": "Matt Bernhardt",
+                    "email": "mjbernha@mit.edu"
+                }
+            ],
+            "description": "Extension to export ACF groups with WP-CFM",
+            "support": {
+                "source": "https://github.com/matt-bernhardt/wp-cfm-acf/tree/0.2.0-beta1"
+            },
+            "time": "2022-03-10T18:49:45+00:00"
         },
         {
             "name": "mitlibraries/mitlib-secrets-widget",
@@ -3579,6 +3606,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
+        "level-level/wp-cfm-acf": 10,
         "mjbernha/mitlib-cube": 10,
         "mjbernha/mitlib-tesseract": 10,
         "roave/security-advisories": 20

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dc570178b30368fffd76e2f2b461ea9a",
+    "content-hash": "ea47533020ad8118df8559f9ffe2822f",
     "packages": [
         {
             "name": "MITLibraries/wp-pending-posts",
-            "version": "1.1.0-beta1",
+            "version": "1.1.0-beta3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/MITLibraries/wp-pending-posts.git",
-                "reference": "4961efcceca61cd3db483014b762f3a6cb6d58b1"
+                "reference": "72cbfac640d88fe9787ab15cfa86f56439029616"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/MITLibraries/wp-pending-posts/zipball/4961efcceca61cd3db483014b762f3a6cb6d58b1",
-                "reference": "4961efcceca61cd3db483014b762f3a6cb6d58b1",
+                "url": "https://api.github.com/repos/MITLibraries/wp-pending-posts/zipball/72cbfac640d88fe9787ab15cfa86f56439029616",
+                "reference": "72cbfac640d88fe9787ab15cfa86f56439029616",
                 "shasum": ""
             },
             "require-dev": {
@@ -33,7 +33,7 @@
                 ]
             },
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-3.0-or-later"
             ],
             "authors": [
                 {
@@ -43,10 +43,10 @@
             ],
             "description": "Displays a \"pending posts\" dashboard widget for admin users",
             "support": {
-                "source": "https://github.com/MITLibraries/wp-pending-posts/tree/1.1.0-beta1",
+                "source": "https://github.com/MITLibraries/wp-pending-posts/tree/1.1.0-beta3",
                 "issues": "https://github.com/MITLibraries/wp-pending-posts/issues"
             },
-            "time": "2022-03-04T17:14:45+00:00"
+            "time": "2022-04-01T20:36:38+00:00"
         },
         {
             "name": "advanced-custom-fields/advanced-custom-fields-pro",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ea47533020ad8118df8559f9ffe2822f",
+    "content-hash": "d190ffee4725ebbdc75d3c3beef04ee4",
     "packages": [
         {
             "name": "MITLibraries/wp-pending-posts",
@@ -344,6 +344,48 @@
                 "issues": "https://github.com/MITLibraries/mitlib-secrets-widget/issues"
             },
             "time": "2020-03-18T19:07:53+00:00"
+        },
+        {
+            "name": "mitlibraries/wp-home-page-news",
+            "version": "2.1.0-beta1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MITLibraries/wp-home-page-news.git",
+                "reference": "7cc6a59fa2c89401a16ae22691df5e5b7e0bc634"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MITLibraries/wp-home-page-news/zipball/7cc6a59fa2c89401a16ae22691df5e5b7e0bc634",
+                "reference": "7cc6a59fa2c89401a16ae22691df5e5b7e0bc634",
+                "shasum": ""
+            },
+            "require-dev": {
+                "squizlabs/php_codesniffer": "^3.6",
+                "wp-coding-standards/wpcs": "^2.3"
+            },
+            "type": "wordpress-plugin",
+            "scripts": {
+                "lint": [
+                    "composer validate --no-check-publish --strict",
+                    "./vendor/bin/phpcs --config-set installed_paths vendor/wp-coding-standards/wpcs",
+                    "./vendor/bin/phpcs -psvn . --standard=codesniffer.full.xml"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Bernhardt",
+                    "email": "mjbernha@mit.edu"
+                }
+            ],
+            "description": "A Wordpress admin widget to list news posts that are promoted to the front page",
+            "support": {
+                "source": "https://github.com/MITLibraries/wp-home-page-news/tree/2.1.0-beta1",
+                "issues": "https://github.com/MITLibraries/wp-home-page-news/issues"
+            },
+            "time": "2022-04-01T21:23:44+00:00"
         },
         {
             "name": "mjbernha/mitlib-cube",
@@ -3649,6 +3691,7 @@
     "minimum-stability": "stable",
     "stability-flags": {
         "level-level/wp-cfm-acf": 10,
+        "mitlibraries/wp-home-page-news": 10,
         "mitlibraries/wp-pending-posts": 10,
         "mjbernha/mitlib-cube": 10,
         "mjbernha/mitlib-tesseract": 10,

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,50 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3371d867d896c673a91087d51ba2e6ae",
+    "content-hash": "dc570178b30368fffd76e2f2b461ea9a",
     "packages": [
+        {
+            "name": "MITLibraries/wp-pending-posts",
+            "version": "1.1.0-beta1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MITLibraries/wp-pending-posts.git",
+                "reference": "4961efcceca61cd3db483014b762f3a6cb6d58b1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MITLibraries/wp-pending-posts/zipball/4961efcceca61cd3db483014b762f3a6cb6d58b1",
+                "reference": "4961efcceca61cd3db483014b762f3a6cb6d58b1",
+                "shasum": ""
+            },
+            "require-dev": {
+                "squizlabs/php_codesniffer": "^3.6",
+                "wp-coding-standards/wpcs": "^2.3"
+            },
+            "type": "wordpress-plugin",
+            "scripts": {
+                "lint": [
+                    "composer validate --no-check-publish --strict",
+                    "./vendor/bin/phpcs --config-set installed_paths vendor/wp-coding-standards/wpcs",
+                    "./vendor/bin/phpcs -psvn . --standard=codesniffer.full.xml"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Bernhardt",
+                    "email": "mjbernha@mit.edu"
+                }
+            ],
+            "description": "Displays a \"pending posts\" dashboard widget for admin users",
+            "support": {
+                "source": "https://github.com/MITLibraries/wp-pending-posts/tree/1.1.0-beta1",
+                "issues": "https://github.com/MITLibraries/wp-pending-posts/issues"
+            },
+            "time": "2022-03-04T17:14:45+00:00"
+        },
         {
             "name": "advanced-custom-fields/advanced-custom-fields-pro",
             "version": "5.12.1",
@@ -3607,6 +3649,7 @@
     "minimum-stability": "stable",
     "stability-flags": {
         "level-level/wp-cfm-acf": 10,
+        "mitlibraries/wp-pending-posts": 10,
         "mjbernha/mitlib-cube": 10,
         "mjbernha/mitlib-tesseract": 10,
         "roave/security-advisories": 20

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,42 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "43d2146936d94cb0c91ed28284a8b564",
+    "content-hash": "93eba9f6647b14afce103fbb98432673",
     "packages": [
+        {
+            "name": "advanced-custom-fields/advanced-custom-fields-pro",
+            "version": "5.12.1",
+            "dist": {
+                "type": "zip",
+                "url": "https://connect.advancedcustomfields.com/v2/plugins/download?p=pro&t=5.12.1"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0",
+                "pivvenit/acf-pro-installer": "^2.4.0 || ^3.0"
+            },
+            "type": "wordpress-plugin",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Elliot Condon",
+                    "homepage": "http://www.elliotcondon.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "PivvenIT",
+                    "homepage": "https://pivvenit.nl",
+                    "role": "Composer Repository maintainer"
+                }
+            ],
+            "description": "Advanced Custom Fields PRO",
+            "homepage": "https://www.advancedcustomfields.com/",
+            "support": {
+                "docs": "https://www.advancedcustomfields.com/resources/",
+                "forum": "https://support.advancedcustomfields.com/topics/"
+            }
+        },
         {
             "name": "composer/installers",
             "version": "v1.12.0",
@@ -446,6 +480,74 @@
                 }
             ],
             "time": "2021-12-04T23:24:31+00:00"
+        },
+        {
+            "name": "pivvenit/acf-pro-installer",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pivvenit/acf-pro-installer.git",
+                "reference": "abf40927ed6f4596700ca35450d1d16e49426222"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pivvenit/acf-pro-installer/zipball/abf40927ed6f4596700ca35450d1d16e49426222",
+                "reference": "abf40927ed6f4596700ca35450d1d16e49426222",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1||^2.0",
+                "ext-json": "*",
+                "php": "^7.3||^8.0",
+                "vlucas/phpdotenv": "^3.0 || ^4.0 || ^5.0"
+            },
+            "replace": {
+                "philippbaschke/acf-pro-installer": "1.0.2"
+            },
+            "require-dev": {
+                "composer/composer": "^1.0|| ^2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "phpstan/phpstan": "^0.12.14",
+                "phpunit/phpunit": "^9.0",
+                "rregeer/phpunit-coverage-check": "^0.3.1",
+                "squizlabs/php_codesniffer": "^3.4",
+                "symfony/process": "^5.1"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PivvenIT\\Composer\\Installers\\ACFPro\\ACFProInstallerPlugin",
+                "plugin-modifies-downloads": true
+            },
+            "autoload": {
+                "psr-4": {
+                    "PivvenIT\\Composer\\Installers\\ACFPro\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PivvenIT",
+                    "homepage": "https://pivvenit.nl"
+                }
+            ],
+            "description": "A modern maintained install helper for Advanced Custom Fields PRO",
+            "keywords": [
+                "acf",
+                "composer",
+                "env",
+                "plugin",
+                "pro",
+                "wordpress",
+                "wp"
+            ],
+            "support": {
+                "issues": "https://github.com/pivvenit/acf-pro-installer/issues",
+                "source": "https://github.com/pivvenit/acf-pro-installer/tree/3.0.0"
+            },
+            "time": "2020-11-21T14:21:09+00:00"
         },
         {
             "name": "roots/wp-password-bcrypt",


### PR DESCRIPTION
This adds the Advanced Custom Fields plugin, which itself requires a bridge package within Composer in order to load projects from private / protected sources.

#### Developer

- [ ] All new secrets documented in README
- [ ] All new secrets have been added to Pantheon tiers
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Includes new or updated dependencies?

YES
